### PR TITLE
Fix composition with non-value toString descriptors

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ const changeToString = (to, from, name) => {
 	const newToString = wrappedToString.bind(null, withName, from.toString());
 	// Ensure `to.toString.toString` is non-enumerable and has the same `same`
 	Object.defineProperty(newToString, 'name', toStringName);
-	const {writable, enumerable, configurable} = toStringDescriptor;
+	const {writable, enumerable, configurable} = toStringDescriptor; // We destructue to avoid a potential `get` descriptor.
 	Object.defineProperty(to, 'toString', {value: newToString, writable, enumerable, configurable});
 };
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ const changeToString = (to, from, name) => {
 	const newToString = wrappedToString.bind(null, withName, from.toString());
 	// Ensure `to.toString.toString` is non-enumerable and has the same `same`
 	Object.defineProperty(newToString, 'name', toStringName);
-	Object.defineProperty(to, 'toString', {...toStringDescriptor, value: newToString});
+	const {writable, enumerable, configurable} = toStringDescriptor;
+	Object.defineProperty(to, 'toString', {value: newToString, writable, enumerable, configurable});
 };
 
 export default function mimicFunction(to, from, {ignoreNonConfigurable = false} = {}) {


### PR DESCRIPTION
This change allows `mimic-fn` to compose with environments where the `toString` property of a function might have a `get` instead of a `value`.

https://github.com/endojs/endo/pull/2144